### PR TITLE
remove replace: true from directives

### DIFF
--- a/dreamfactory-user-management.js
+++ b/dreamfactory-user-management.js
@@ -64,10 +64,7 @@ angular.module('dfUserManagement', ['ngRoute', 'ngCookies'])
 
                 // only allow as HTML tag
                 restrict: 'E',
-
-                // don't show directive tag
-                replace: true,
-
+                
                 // isolate scope
                 scope: {
 
@@ -252,7 +249,6 @@ angular.module('dfUserManagement', ['ngRoute', 'ngCookies'])
 
         return {
             restrict: 'E',
-            replace: true,
             scope: false,
             templateUrl: MODUSRMNGR_ASSET_PATH + 'views/fp-email-conf.html',
             link: function (scope, elem, attrs) {


### PR DESCRIPTION
This module fails to render certain templates in recent versions of AngularJS such as 1.3.15 due a bug in AngularJS 

https://github.com/angular/angular.js/issues/9837

Also having a replace: true does not have a big impact from a functional point of view. It is just replacing the inner content with the actual directive tag. And the AngularJS community has started indicating that they will no longer support replace attribute for directives in future. Check:
https://github.com/angular/angular.js/commit/eec6394a342fb92fba5270eee11c83f1d895e9fb#commitcomment-8124407
http://stackoverflow.com/a/24195251/1221279

Hence I think removing "replace: true" might be a great idea since a lot of customers have started using AngularJS 1.3 and above.